### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.0.0
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v2.3.5
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.0.0
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
           server-id: github
           settings-path: ${{ github.workspace }}
 


### PR DESCRIPTION
The 'adopt' distribution has moved to Eclipse Temurin.

It won't be updated at the AdoptOpenJDK location.

See https://github.com/jenkinsci/jenkins/pull/6406

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt

https://github.com/actions/setup-java#usage
