### PR TITLE
Store secrets as EnvVars to avoid printing them in logs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.41</version>
-        <relativePath/>
     </parent>
     <groupId>com.checkmarx.jenkins</groupId>
     <artifactId>checkmarx-ast-scanner</artifactId>
@@ -52,7 +51,6 @@
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.version>2.263.1</jenkins.version>
-        <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 
@@ -118,7 +116,7 @@
         <dependency>
             <groupId>org.jodd</groupId>
             <artifactId>jodd-lagarto</artifactId>
-            <version>6.0.6</version>
+            <version>6.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -178,9 +176,6 @@
                 <artifactId>maven-hpi-plugin</artifactId>
                 <version>3.28</version>
                 <extensions>true</extensions>
-                <configuration>
-                    <minimumJavaVersion>8</minimumJavaVersion>
-                </configuration>
             </plugin>
             <!--            <plugin>-->
             <!--                 This override has been skipped for building with Java 11-->

--- a/src/main/java/com/checkmarx/jenkins/CheckmarxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CheckmarxScanBuilder.java
@@ -221,6 +221,8 @@ public class CheckmarxScanBuilder extends Builder implements SimpleBuildStep {
             return;
         }
 
+        PluginUtils.insertSecretsAsEnvVars(scanConfig, envVars );
+
         printConfiguration(envVars, descriptor, log);
 
         if (!getUseOwnServerCredentials()) checkmarxInstallation = descriptor.getCheckmarxInstallation();

--- a/src/main/java/com/checkmarx/jenkins/PluginUtils.java
+++ b/src/main/java/com/checkmarx/jenkins/PluginUtils.java
@@ -7,14 +7,12 @@ import com.checkmarx.ast.wrapper.CxException;
 import com.checkmarx.ast.wrapper.CxWrapper;
 import com.checkmarx.jenkins.model.ScanConfig;
 import com.checkmarx.jenkins.tools.CheckmarxInstallation;
+import hudson.EnvVars;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -26,6 +24,9 @@ public class PluginUtils {
     public static final String CHECKMARX_AST_RESULTS_JSON = "checkmarx-ast-results.json";
     public static final String REGEX_SCAN_ID_FROM_LOGS = "(ID)\":\"((\\\\\"|[^\"])*)";
     private static final String JENKINS = "Jenkins";
+    static final String CX_CLIENT_ID_ENV_KEY = "CX_CLIENT_ID";
+    static final String CX_CLIENT_SECRET_ENV_KEY = "CX_CLIENT_SECRET";
+    static final String PRINT_ASTERISKS = "*****";
 
     public static CheckmarxInstallation findCheckmarxInstallation(final String checkmarxInstallation) {
         final CheckmarxScanBuilder.CheckmarxScanBuilderDescriptor descriptor = Jenkins.get().getDescriptorByType(CheckmarxScanBuilder.CheckmarxScanBuilderDescriptor.class);
@@ -41,7 +42,7 @@ public class PluginUtils {
         cxConfig.setAdditionalParameters(scanConfig.getAdditionalOptions());
 
         final Map<String, String> params = new HashMap<>();
-        params.put(CxConstants.AGENT, PluginUtils.JENKINS);
+        params.put(CxConstants.AGENT, JENKINS);
         params.put(CxConstants.SOURCE, scanConfig.getSourceDirectory());
         params.put(CxConstants.PROJECT_NAME, scanConfig.getProjectName());
         params.put(CxConstants.BRANCH, scanConfig.getBranchName());
@@ -82,8 +83,8 @@ public class PluginUtils {
         return CxConfig.builder()
                 .baseUri(scanConfig.getServerUrl())
                 .baseAuthUri(scanConfig.getBaseAuthUrl())
-                .clientId(scanConfig.getCheckmarxToken().getClientId())
-                .clientSecret(scanConfig.getCheckmarxToken().getToken().getPlainText())
+                .clientId(PRINT_ASTERISKS)
+                .clientSecret(PRINT_ASTERISKS)
                 .tenant(scanConfig.getTenantName())
                 .additionalParameters(null)
                 .pathToExecutable(checkmarxCliExecutable)
@@ -98,6 +99,11 @@ public class PluginUtils {
             return matcher.group(2);
         }
         return "";
+    }
+
+    public static void insertSecretsAsEnvVars(ScanConfig scanConfig, EnvVars envVars) throws IOException, InterruptedException {
+        envVars.put(CX_CLIENT_ID_ENV_KEY,scanConfig.getCheckmarxToken().getClientId());
+        envVars.put(CX_CLIENT_SECRET_ENV_KEY, scanConfig.getCheckmarxToken().getToken().getPlainText());
     }
 
 }

--- a/src/main/java/com/checkmarx/jenkins/PluginUtils.java
+++ b/src/main/java/com/checkmarx/jenkins/PluginUtils.java
@@ -26,7 +26,6 @@ public class PluginUtils {
     private static final String JENKINS = "Jenkins";
     static final String CX_CLIENT_ID_ENV_KEY = "CX_CLIENT_ID";
     static final String CX_CLIENT_SECRET_ENV_KEY = "CX_CLIENT_SECRET";
-    static final String PRINT_ASTERISKS = "*****";
 
     public static CheckmarxInstallation findCheckmarxInstallation(final String checkmarxInstallation) {
         final CheckmarxScanBuilder.CheckmarxScanBuilderDescriptor descriptor = Jenkins.get().getDescriptorByType(CheckmarxScanBuilder.CheckmarxScanBuilderDescriptor.class);
@@ -83,8 +82,6 @@ public class PluginUtils {
         return CxConfig.builder()
                 .baseUri(scanConfig.getServerUrl())
                 .baseAuthUri(scanConfig.getBaseAuthUrl())
-                .clientId(PRINT_ASTERISKS)
-                .clientSecret(PRINT_ASTERISKS)
                 .tenant(scanConfig.getTenantName())
                 .additionalParameters(null)
                 .pathToExecutable(checkmarxCliExecutable)


### PR DESCRIPTION
This is a bugfix that stores the AST credentials as Env Vars to avoid printing them in logs.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
