### PR TITLE
Update ast-cli-java-wrapper to version 2.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
         </dependency>
         <dependency>
             <groupId>com.checkmarx.ast</groupId>
-            <artifactId>ast-cli-java-wrapper</artifactId>
-            <version>2.1.7</version>
+        <artifactId>ast-cli-java-wrapper</artifactId>
+        <version>2.1.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This PR updates the ast-cli-java-wrapper dependency in pom.xml to version 2.1.8.