### PR TITLE
Fix unmatched paren in publish-pre-release.yml

### DIFF
--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -27,7 +27,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     outputs:
-      should_release: ${{ (steps.verify-ci-status.outputs.result == 'success' }}
+      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' }}
     steps:
       - name: Verify CI status
         uses: jenkins-infra/verify-ci-status-action@7d194d0c5785a12623f350581db5243063542f90 #v1.2.2


### PR DESCRIPTION
## Summary
- The `should_release` output expression in `publish-pre-release.yml` contained an opening `(` with no matching `)`, making the workflow file unparseable.
- GitHub registered a 0s **failure** run of `publish-pre-release.yml` on every push (see e.g. run [25611729253](https://github.com/jenkinsci/checkmarx-ast-scanner-plugin/actions/runs/25611729253), and the same on every prior push for at least the last several commits).
- Removing the stray `(` restores parsing. The expression's logic is unchanged.

```diff
-      should_release: ${{ (steps.verify-ci-status.outputs.result == 'success' }}
+      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' }}
```

## Test plan
- [ ] Confirm the next push to `main` (post-merge) no longer produces a 0s failed run for `publish-pre-release.yml`.
- [ ] Optional: trigger the workflow via `workflow_dispatch` with `tag=nightly` to confirm `validate` → `release` gating still behaves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)