### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CheckmarxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CheckmarxScanBuilder.java
@@ -29,7 +29,7 @@ import jenkins.tasks.SimpleBuildStep;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.verb.POST;

--- a/src/main/java/com/checkmarx/jenkins/tools/CheckmarxInstaller.java
+++ b/src/main/java/com/checkmarx/jenkins/tools/CheckmarxInstaller.java
@@ -31,7 +31,7 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.*;

--- a/src/main/java/com/checkmarx/jenkins/tools/ProxyHttpClient.java
+++ b/src/main/java/com/checkmarx/jenkins/tools/ProxyHttpClient.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.checkmarx.jenkins.exception.CheckmarxException;
 import okhttp3.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
 

--- a/src/test/java/com/checkmarx/jenkins/integration/CheckmarxScanBuilderTest.java
+++ b/src/test/java/com/checkmarx/jenkins/integration/CheckmarxScanBuilderTest.java
@@ -13,7 +13,7 @@ import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
 import hudson.util.FormValidation;
 import jenkins.model.ArtifactManager;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import java.util.logging.Logger;


### PR DESCRIPTION
This repository was previously using an inconsistent mix of versions.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

The plugin already depends on `commons-lang3-api`; four files were still importing the Commons
Lang 2 package. This switches them over.

### Testing done

`mvn -B -ntp clean verify` compiles and passes the unit tests on Java 21 / macOS.

The 11 tests in `CheckmarxScanBuilderTest` error out in my environment, but for an unrelated reason:
`CheckmarxTestBase.before()` reads `CX_CLIENT_ID`, `CX_CLIENT_SECRET`, `CX_TENANT` and friends from the
environment, and without real Checkmarx AST credentials `DefaultCheckmarxApiToken` throws
`NullPointerException: clientId is marked non-null but is null`. That is environmental and has nothing to
do with this change, which only touches import lines.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `4.88` was out of scope here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
